### PR TITLE
main.js: Improve dark mode

### DIFF
--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -338,6 +338,12 @@ class ThemeToggler extends HTMLAnchorElement {
     this.innerText = "◑";
     this.setAttribute("aria-hidden", "true");
     this.style.cursor = "pointer";
+
+    // Add color-scheme meta tag to style buttons
+    const colorSchemeMeta = document.createElement("meta");
+    colorSchemeMeta.name = "color-scheme";
+    colorSchemeMeta.content = this.theme;
+    document.head.appendChild(colorSchemeMeta);
   }
 
   click() {
@@ -369,6 +375,7 @@ class ThemeToggler extends HTMLAnchorElement {
       $(".corner .bordered").style.border = "1px solid black";
       $$("a").forEach((e) => { e.style.color = "black" });
     }
+    $("meta[name=color-scheme]").content = this.theme;
   }
 }
 


### PR DESCRIPTION
Make use of the [`color-scheme` meta tag][0] to style buttons and other  widgets to match the selected color scheme.

When the scheme is toggled, the `content` of the tag is set to "light"  or "dark" to tell the user agent how to theme input elements, which  should match the colors of the rest of the app.

Here's a screenshot on Firefox with the dark mode changes:

![The Trunkless app in dark mode, with its buttons also styled with dark backgrounds](https://github.com/user-attachments/assets/406ac299-09f8-4abb-9d98-5eb0a6e358e7)


[0]: https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme